### PR TITLE
fix: provide missing logic to exclude parents of nested packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.3.2]
+- Fix: provide missing logic to exclude parents of nested packages
+
 ## [0.3.1]
 - Fix a bug with subpackage identification caused by incorrect matching approach
 

--- a/depcheck/models.py
+++ b/depcheck/models.py
@@ -106,7 +106,15 @@ class DependencyReport:
 
     @staticmethod
     def __exclude_inner_dependencies(raw_dependencies: set[str], layers: set[str]) -> set[str]:
-        return raw_dependencies - layers
+        filtered_deps = []
+        deps = raw_dependencies - layers
+
+        for dep in deps:
+            temp = [lp for lp in layers if lp.startswith(dep)]
+            if len(temp) > 0:
+                continue
+            filtered_deps.append(dep)
+        return set(filtered_deps)
 
     def __layer_packages(self, layers: list[str]) -> set[str]:
         if layers is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "depcheck"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["FlixMobility Tech <open-source@flixbus.com>"]
 description = "Python code quality package that helps in defining and restricting how components of your code may interact"
 license = "MIT"


### PR DESCRIPTION
If a package X.Y has its own layer, this fix ensures that there is no implicitly detected dependency on package X. Basically allowing package X.Y to have independent rules than package X.